### PR TITLE
fix: breaking changes from aes-siv and cosmrs deps

### DIFF
--- a/src/client/tx.rs
+++ b/src/client/tx.rs
@@ -82,6 +82,7 @@ impl super::Client {
             sender: account.id(),
             contract: contract.id(),
             msg: encrypted_msg,
+            sent_funds: vec![],
         };
 
         let decrypter = self.decrypter(&nonce, account)?;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,4 +1,4 @@
-use aes_siv::{siv::Aes128Siv as Siv, Key as SivKey};
+use aes_siv::{siv::Aes128Siv as Siv, Key as SivKey, KeyInit};
 
 pub mod cert;
 
@@ -35,7 +35,7 @@ pub fn encrypt(
 
     let shared_secret = encryption_key(secret, peer, &nonce)?;
 
-    let mut cipher = Siv::new(SivKey::from(shared_secret));
+    let mut cipher = Siv::new(&SivKey::<Siv>::from(shared_secret));
 
     let ciphertext = cipher
         .encrypt(&[[]], plaintext)
@@ -54,7 +54,7 @@ pub fn decrypt(
 ) -> Result<Vec<u8>, CryptoError> {
     let shared_secret = encryption_key(secret, peer, &nonce)?;
 
-    let mut cipher = Siv::new(SivKey::from(shared_secret));
+    let mut cipher = Siv::new(&SivKey::<Siv>::from(shared_secret));
 
     let plaintext = cipher
         .decrypt(&[[]], ciphertext)


### PR DESCRIPTION
In `crypto.rs`: Import the `KeyInit` trait to regain access to `Siv::new` method, which now takes a reference.

In `tx.rs`: Add a `sent_funds` field which is now required by `MsgExecuteContract`.